### PR TITLE
Update endpoints to DNS names, made "ops" the default unity environment.

### DIFF
--- a/.github/workflows/unity-py-python-app.yml
+++ b/.github/workflows/unity-py-python-app.yml
@@ -7,12 +7,12 @@ name: Unity-sds-client Python Build
 # Run on an PR if it includes unity-py changes OR if the schema in health are changed.
 on:
   push:
-    branches: 
+    branches:
     - main
-    paths: 
+    paths:
     - 'libs/unity-py/**'
   pull_request:
-    branches: 
+    branches:
     - main
     paths:
     - 'libs/unity-py/**'
@@ -47,7 +47,7 @@ jobs:
       with:
         filters: |
           src:
-            - 'libs/unity-py/**'
+            - '**'
     - name: Software Version Check
       if: steps.filter.outputs.src == 'true'
       run: |
@@ -79,12 +79,12 @@ jobs:
         UNITY_USER: '${{ secrets.UNITY_TEST_USER }}'
         UNITY_PASSWORD: '${{ secrets.UNITY_TEST_PASSWORD }}'
       run: |
-        poetry run pytest --cov-report=lcov --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG 
+        poetry run pytest --cov-report=lcov --cov=unity_sds_client -o log_cli=true --log-cli-level=DEBUG
     - name: Coveralls
       uses: coverallsapp/github-action@v2.3.0
   version:
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' 
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -99,12 +99,12 @@ jobs:
         uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: "1.5.1"
-      # Commented out the version bump code. Will publish new unity-py version to pypi on push to main. 
+      # Commented out the version bump code. Will publish new unity-py version to pypi on push to main.
       # This means we are always releasing. This will fail if the version already exists in Pypi.
       # We must ensure that the version has been updated.
       # ADded version check above.
       # Future work: set PR test to ensure the version has been updated.
-      
+
       # - name: version-bump
       #   run: |
       #     poetry version prerelease

--- a/.github/workflows/unity-py-python-app.yml
+++ b/.github/workflows/unity-py-python-app.yml
@@ -47,9 +47,9 @@ jobs:
       with:
         filters: |
           src:
-            - '**'
+            - 'libs/unity-py/**'
     - name: Software Version Check
-      if: steps.filter.outputs.src == 'true'
+      if: steps.changes.outputs.src == 'true'
       run: |
         unity_py_proposed_version=`poetry version -s`
         echo "curl -s -o /dev/null -w \"%{http_code}\" https://pypi.org/project/unity-sds-client/$unity_py_proposed_version/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,15 @@ repos:
     hooks:
       - id: ruff
 
+  # unity-py bandit config
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.8" # you must change this to newest version
     hooks:
       - id: bandit
+        files: '^libs/unity-py/.*\.py'
         args:
           [
-            "--configfile=pyproject.toml",
+            "--configfile=libs/unity-py/pyproject.toml",
             "--severity-level=high",
             "--confidence-level=high",
           ]

--- a/libs/unity-py/CHANGELOG.md
+++ b/libs/unity-py/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-07-31
+### Added
+### Fixed
+* cleaned up some README formatting
+### Changed
+* changed endpoints from cloudfront urls to DNS entries
+### Removed
+### Security
+### Deprecated
+
 
 ## [0.5.0] - 2024-07-23
 

--- a/libs/unity-py/pyproject.toml
+++ b/libs/unity-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.5.0"
+version = "0.5.1"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/libs/unity-py/unity_sds_client/envs/environments.cfg
+++ b/libs/unity-py/unity_sds_client/envs/environments.cfg
@@ -1,23 +1,14 @@
 [DEV]
 client_id = 40c2s0ulbhp9i0fmaph3su9jch
 auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
-unity_href = https://d3vc8w9zcq658.cloudfront.net/
+unity_href = https://api.dev.mdps.mcp.nasa.gov/
 
 [TEST]
 client_id = 71894molftjtie4dvvkbjeard0
 auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
-unity_href = https://dxebrgu0bc9w7.cloudfront.net/
+unity_href = https://api.test.mdps.mcp.nasa.gov/
 
 [PROD]
 client_id = 7vehllplbone6p4usqgutqun35
 auth_endpoint = https://cognito-idp.us-west-2.amazonaws.com
-unity_href = https://d2zjsabg0fonik.cloudfront.net/
-
-;[APPLICATIONS]
-;
-;
-;[DATA]
-;dapa_endpoint = https://58nbcawrvb.execute-api.us-west-2.amazonaws.com/test/
-;
-;[SPS]
-;sps_endpoint = http://a22b9d7b66df24e6fb3326ecd4cb0614-676486270.us-west-2.elb.amazonaws.com:5001/
+unity_href = https://api.mdps.mcp.nasa.gov/

--- a/libs/unity-py/unity_sds_client/unity.py
+++ b/libs/unity-py/unity_sds_client/unity.py
@@ -1,12 +1,13 @@
 import os
 from configparser import ConfigParser, ExtendedInterpolation
+
 from unity_sds_client.services.data_service import DataService
-from unity_sds_client.services.process_service import ProcessService
 from unity_sds_client.services.health_service import HealthService
-from unity_sds_client.unity_session import UnitySession
-from unity_sds_client.unity_exception import UnityException
+from unity_sds_client.services.process_service import ProcessService
 from unity_sds_client.unity_environments import UnityEnvironments
+from unity_sds_client.unity_exception import UnityException
 from unity_sds_client.unity_services import UnityServices
+from unity_sds_client.unity_session import UnitySession
 
 
 class Unity(object):
@@ -16,16 +17,22 @@ class Unity(object):
     is passed to different services and resources as needed.
     """
 
-    def __init__(self, environment: UnityEnvironments = UnityEnvironments.TEST, config_file_override:str = None):
+    def __init__(
+        self,
+        environment: UnityEnvironments = UnityEnvironments.PROD,
+        config_file_override: str = None,
+    ):
         """
-        :param environment: the default environment for a session to work with. Defaults to 'TEST' unity environment.
+        :param environment: the default environment for a session to work with. Defaults to 'PROD' unity environment.
         :param config_file_override: absolute path to a config file containing settings to override default config
         """
         env = environment
-        config = _read_config([
-            os.path.dirname(os.path.realpath(__file__)) + "/envs/environments.cfg".format(str(env.value).lower()),
-            config_file_override
-        ])
+        config = _read_config(
+            [
+                os.path.dirname(os.path.realpath(__file__)) + "/envs/environments.cfg",
+                config_file_override,
+            ]
+        )
         self._session = UnitySession(env.value, config)
 
     def set_project(self, project):
@@ -33,7 +40,7 @@ class Unity(object):
         :param project: the project to use when interacting with venue specific services. Used in building the restful
         endpoint.
         """
-        self._session._project  = project
+        self._session._project = project
 
     def set_venue(self, venue):
         """
@@ -66,15 +73,20 @@ class Unity(object):
     def __str__(self):
         response = "\nUNITY CONFIGURATION"
         response = response + "\n" + len(response) * "-" + "\n"
-        
+
         config = self._session.get_config()
         config_sections = config.sections()
         for section in config_sections:
             response = response + "\n[{}]\n".format(section)
             for setting in dict(config[section]):
-                response = response + "{}: {}\n".format(setting, dict(config[section])[setting])
+                response = response + "{}: {}\n".format(
+                    setting, dict(config[section])[setting]
+                )
 
-        response = response + self.client(UnityServices.HEALTH_SERVICE).generate_health_status_report()
+        response = (
+            response
+            + self.client(UnityServices.HEALTH_SERVICE).generate_health_status_report()
+        )
 
         return response
 


### PR DESCRIPTION
## Purpose
- Update endpoints to DNS names form cloudfront URLS
## Proposed Changes
- Changed Cloudfront urls to DNS names in environment.cfg
- Changed default environment to operations from test. Can be overridden manually.

## Testing
- ran poetry run pytest
- Ran some sanity checks using mdps-tutorials repository to ensure endpoint acessibility.
