### PR TITLE
Update unity_sds_client with Data Service Delete

### DIFF
--- a/.github/workflows/unity-py-python-app.yml
+++ b/.github/workflows/unity-py-python-app.yml
@@ -52,8 +52,9 @@ jobs:
       if: steps.changes.outputs.src == 'true'
       run: |
         unity_py_proposed_version=`poetry version -s`
-        echo "curl -s -o /dev/null -w \"%{http_code}\" https://pypi.org/project/unity-sds-client/$unity_py_proposed_version/"
-        status_code=`curl -s -o /dev/null -w "%{http_code}" https://pypi.org/project/unity-sds-client/$unity_py_proposed_version/`
+        #  https://pypi.org/pypi/unity-sds-client/0.8.0/json
+        echo "curl -s -o /dev/null -w \"%{http_code}\" https://pypi.org/pypi/unity-sds-client/$unity_py_proposed_version/json"
+        status_code=`curl -s -o /dev/null -w \"%{http_code}\" https://pypi.org/pypi/unity-sds-client/$unity_py_proposed_version/json`
         echo "Received status code of $status_code"
         if ((status_code == 200)); then
           echo "Version already exists."

--- a/libs/unity-py/CHANGELOG.md
+++ b/libs/unity-py/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2025-1-14
+
+### Added
+
+### Fixed
+
+### Changed
+
+    Updated the unity-py to include the Data Service Delete.
+
+### Removed
+
+### Security
+
+### Deprecated
+
 ## [0.7.0] - 2024-11-21
 
 ### Added

--- a/libs/unity-py/pyproject.toml
+++ b/libs/unity-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.7.0"
+version = "0.8.0"
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]
 readme = "README.md"

--- a/libs/unity-py/tests/catalog.json
+++ b/libs/unity-py/tests/catalog.json
@@ -1,0 +1,18 @@
+{
+  "type": "Catalog",
+  "id": "urn:nasa:unity:emit:dev:my_test_collection_id2___1",
+  "stac_version": "1.0.0",
+  "description": "STAC Catalog",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./urn:nasa:unity:emit:dev:my_test_collection_id2___1.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/libs/unity-py/tests/test_unity_data_service.py
+++ b/libs/unity-py/tests/test_unity_data_service.py
@@ -50,17 +50,3 @@ def test_collection_creation(cleanup_update_test):
     ds = s.client(Services.DATA_SERVICE)
     ds.create_collection(Collection("urn:nasa:unity:unity:test:my_collection_id"), True)
 
-def test_collection_deletion():
-
-    unity = Unity(UnityEnvironments.TEST)
-    token = unity._session.get_auth().get_token()
-    data_service = unity.client(Services.DATA_SERVICE)
-
-    collections = data_service.get_collections(100)
-
-    granule_id = 'urn:nasa:unity:emit:dev:unity-tutorial___1:summary_table.txt'
-
-    for i in range(len(collections)):
-        if granule_id in collections[i].collection_id:
-            data_service.delete_collection_data(collections[i], granule_id)
-            break

--- a/libs/unity-py/tests/test_unity_data_service.py
+++ b/libs/unity-py/tests/test_unity_data_service.py
@@ -1,6 +1,7 @@
 from unity_sds_client.unity import Unity
 from unity_sds_client.unity_exception import UnityException
 from unity_sds_client.unity_session import UnitySession
+from unity_sds_client.unity import UnityEnvironments
 from unity_sds_client.resources.collection import Collection
 from unity_sds_client.unity_services import UnityServices as Services
 
@@ -48,3 +49,18 @@ def test_collection_creation(cleanup_update_test):
     s.set_venue("test")
     ds = s.client(Services.DATA_SERVICE)
     ds.create_collection(Collection("urn:nasa:unity:unity:test:my_collection_id"), True)
+
+def test_collection_deletion():
+
+    unity = Unity(UnityEnvironments.TEST)
+    token = unity._session.get_auth().get_token()
+    data_service = unity.client(Services.DATA_SERVICE)
+
+    collections = data_service.get_collections(100)
+
+    granule_id = 'urn:nasa:unity:emit:dev:unity-tutorial___1:summary_table.txt'
+
+    for i in range(len(collections)):
+        if granule_id in collections[i].collection_id:
+            data_service.delete_collection_data(collections[i], granule_id)
+            break

--- a/libs/unity-py/tests/urn:nasa:unity:emit:dev:my_test_collection_id2.json
+++ b/libs/unity-py/tests/urn:nasa:unity:emit:dev:my_test_collection_id2.json
@@ -1,0 +1,37 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "stac_extensions": [],
+  "id": "urn:nasa:unity:emit:dev:my_test_collection_id2",
+  "geometry": null,
+  "properties": {
+    "datetime": "2025-01-15T21:14:21.497488Z",
+    "start_datetime": "2025-01-15T21:14:21.497488+00:00",
+    "end_datetime": "2025-01-15T21:14:21.498540+00:00",
+    "created": "2025-01-15T21:14:21.498554+00:00",
+    "updated": "2025-01-15T21:14:21.498757Z"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "test_data_item.hdr": {
+      "href": "test_data_item.hdr",
+      "title": "hdr file",
+      "description": "",
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "collection": "urn:nasa:unity:emit:dev:my_test_collection_id2"
+}

--- a/libs/unity-py/tests/urn:nasa:unity:emit:dev:my_test_collection_id2___1.json
+++ b/libs/unity-py/tests/urn:nasa:unity:emit:dev:my_test_collection_id2___1.json
@@ -1,0 +1,37 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "stac_extensions": [],
+  "id": "urn:nasa:unity:emit:dev:my_test_collection_id2___1",
+  "geometry": null,
+  "properties": {
+    "datetime": "2025-01-15T21:26:11.604091Z",
+    "start_datetime": "2025-01-15T21:26:11.604091+00:00",
+    "end_datetime": "2025-01-15T21:26:11.604993+00:00",
+    "created": "2025-01-15T21:26:11.605018+00:00",
+    "updated": "2025-01-15T21:26:11.605237Z"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "test_data_item.hdr": {
+      "href": "test_data_item.hdr",
+      "title": "hdr file",
+      "description": "",
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "collection": "urn:nasa:unity:emit:dev:my_test_collection_id2___1"
+}

--- a/libs/unity-py/unity_sds_client/services/data_service.py
+++ b/libs/unity-py/unity_sds_client/services/data_service.py
@@ -190,3 +190,20 @@ class DataService(object):
                                 params={"venue": self._session._venue}, json=metadata)
         if response.status_code != 200:
             raise UnityException("Error adding custom metadata: " + response.message)
+
+    #
+    #Delete single granule from a given Collection
+    #
+    def delete_collection_data(self, collection: type = Collection, granule_id: str = None):
+        #Must provide granule_id
+        if (granule_id == "") or (granule_id is None):
+            raise Exception("Error deleting collection data: Please provide granule ID")
+
+        else:
+            url = f'{self.endpoint}am-uds-dapa/collections/{collection.collection_id}/items/{granule_id}/'        
+            token = self._session.get_auth().get_token()        
+            header = {"Authorization": f"Bearer {token}"}
+            response = requests.delete(url=url, headers=header)
+            print(response.status_code)
+            if response.status_code != 200:
+                raise UnityException("Error deleting collection: " + response.reason)   

--- a/libs/unity-py/unity_sds_client/services/data_service.py
+++ b/libs/unity-py/unity_sds_client/services/data_service.py
@@ -191,11 +191,17 @@ class DataService(object):
         if response.status_code != 200:
             raise UnityException("Error adding custom metadata: " + response.message)
 
-    #
-    #Delete single granule from a given Collection
-    #
-    def delete_collection_data(self, collection: type = Collection, granule_id: str = None):
-        #Must provide granule_id
+    def delete_collection_item(self, collection: type = Collection, granule_id: str = None):
+        """
+            Delete a granule from given a collection
+            Parameters
+            -------
+            collection: Collection
+                The collection object associated to the granule to delete
+            granule_id: String
+                The granule id to delete
+
+    	""" 
         if (granule_id == "") or (granule_id is None):
             raise Exception("Error deleting collection data: Please provide granule ID")
 
@@ -207,3 +213,13 @@ class DataService(object):
             print(response.status_code)
             if response.status_code != 200:
                 raise UnityException("Error deleting collection: " + response.reason)   
+
+    def delete_dataset(self, dataset: type = Dataset):
+        """
+            Delete an item from a Collection given Dataset object  
+            Parameters
+            ----------
+            dataset: Dataset
+        """
+    
+        self.delete_collection_item(Collection(dataset.collection_id), dataset.id)


### PR DESCRIPTION
## Purpose
- Updated unity_sds_client to include the "delete_collection_data" function for Data Service.

## Proposed Changes
- Added "delete_collection_data" function for Data Service. Requires the collection object and granule_id. 
## Issues
- https://github.com/unity-sds/unity-project-management/issues/225
## Testing
Code for testing:
from unity_sds_client.unity import Unity
from unity_sds_client.unity_services import UnityServices
from unity_sds_client.unity import UnityEnvironments
from unity_sds_client.resources.collection import Collection
import requests

unity = Unity(UnityEnvironments.PROD)
token = unity._session.get_auth().get_token()
data_service = unity.client(UnityServices.DATA_SERVICE)

collections = data_service.get_collections(100)

granule_id = 'urn:nasa:unity:emit:dev:emit_ghg_test___1:emit20230809T105356_ch4_mf'

for i in range(len(collections)):
    if 'urn:nasa:unity:emit:dev:emit_ghg_test___1' in collections[i].collection_id:
        data_service.delete_collection_data(collections[i], granule_id)
        break

