### PR TITLE
Unity-CS #452 - push logs to S3 instead of GitHub

### DIFF
--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -522,8 +522,10 @@ echo "$EVENTS" > CF_EVENTS.txt
 cat CF_EVENTS.txt
 CF_EVENTS=$(cat CF_EVENTS.txt)
 
+#
+# Clean up logs and push up to S3 if configured
+#
 if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
-    # cleanup logs and push up to S3
 
     # Delete logs older then 2 weeks, if any
     bash delete_old_logs.sh

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -502,25 +502,6 @@ else
     echo "Not running BDD tests. (--run-bdd-tests false)" >> nightly_output.txt
 fi
 
-if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
-    # cleanup logs and push up to S3
-
-    # Delete logs older then 2 weeks, if any
-    bash delete_old_logs.sh
-      
-    if [[ -n $LOG_S3_PATH ]]; then
-        # Push the output logs/screenshots to S3 for review/auditing purposesa
-        echo "Pushing test results to ${LOG_S3_PATH}..."
-        if aws s3 cp ${LOG_DIR} ${LOG_S3_PATH}/${LOG_DIR} --recursive; then
-            echo "Test results successfully pushed to S3."
-        else
-            echo "Error pushing test results to S3. Log files remain locally in ${LOG_DIR}"
-        fi
-    else
-        echo "Not pushing results to S3 because no log-s3-path was specified on the command line. Log files remian locally in ${LOG_DIR}"
-    fi
-fi
-
 # Decide on resource destruction based on the smoke test result or DESTROY flag
 if [[ "$DESTROY" == "true" ]] || [ $SMOKE_TEST_STATUS -ne 0 ]; then
   # This sleep appears to eliminate a timine issue w/ DynamoDB and the terraform lock file.
@@ -540,6 +521,25 @@ EVENTS=$(cat CF_EVENTS.txt |grep -v ResourceProperties)
 echo "$EVENTS" > CF_EVENTS.txt
 cat CF_EVENTS.txt
 CF_EVENTS=$(cat CF_EVENTS.txt)
+
+if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
+    # cleanup logs and push up to S3
+
+    # Delete logs older then 2 weeks, if any
+    bash delete_old_logs.sh
+
+    if [[ -n $LOG_S3_PATH ]]; then
+        # Push the output logs/screenshots to S3 for review/auditing purposesa
+        echo "Pushing test results to ${LOG_S3_PATH}..."
+        if aws s3 cp ${LOG_DIR} ${LOG_S3_PATH}/${LOG_DIR} --recursive; then
+            echo "Test results successfully pushed to S3."
+        else
+            echo "Error pushing test results to S3. Log files remain locally in ${LOG_DIR}"
+        fi
+    else
+        echo "Not pushing results to S3 because no log-s3-path was specified on the command line. Log files remian locally in ${LOG_DIR}"
+    fi
+fi
 
 # The rest of your script, including posting to Slack, can go here
 # Ensure to only post to Slack if tests were run 

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -513,8 +513,6 @@ if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
         echo "Pushing test results to ${LOG_S3_PATH}..."
         if aws s3 cp ${LOG_DIR} ${LOG_S3_PATH}/${LOG_DIR} --recursive; then
             echo "Test results successfully pushed to S3."
-            # clean up log dir
-            rm -r $LOG_DIR
         else
             echo "Error pushing test results to S3. Log files remain locally in ${LOG_DIR}"
         fi

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -10,11 +10,12 @@ MC_VERSION="latest"
 GH_BRANCH="main"
 DEPLOYMENT_START_TIME=$(date +%s)
 MC_SHA=""
+LOG_S3_PATH=""
 CONFIG_FILE="marketplace_config.yaml"  # Set default config file
 # Function to display usage instructions
 # TODO: refine the command line selection of tests, e.g. use behave tags for BDD testing and implicit tags for other (e.g. selenium) testing
 usage() {
-    echo "Usage: $0 --destroy <true|false> --run-tests <true|false> --project-name <PROJECT_NAME> --venue-name <VENUE_NAME> [--mc-version <MC_VERSION>] [--mc-sha <MC_SHA>] [--config-file <CONFIG_FILE>] [--run-bdd-tests <true|false>] [--testrail <true|false>] [--repo-branch <branch>]"
+    echo "Usage: $0 --destroy <true|false> --run-tests <true|false> --project-name <PROJECT_NAME> --venue-name <VENUE_NAME> [--log-s3-path <LOG_S3_PATH>] [--mc-version <MC_VERSION>] [--mc-sha <MC_SHA>] [--config-file <CONFIG_FILE>] [--run-bdd-tests <true|false>] [--testrail <true|false>] [--repo-branch <branch>]"
     echo "    --run-bdd-tests and --run-tests are independent from one another. But --testrail is considered only if --run-bbd-tests is active. Default for both --run-bdd-tests and --testrail are false."
     exit 1
 }
@@ -88,6 +89,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --venue-name)
             VENUE_NAME="$2"
+            shift 2
+            ;;
+        --log-s3-path)
+            LOG_S3_PATH="$2"
             shift 2
             ;;
         --mc-version)
@@ -497,28 +502,30 @@ else
     echo "Not running BDD tests. (--run-bdd-tests false)" >> nightly_output.txt
 fi
 
-if [[ "y" == "n" ]]; then
-    # No longer committing logs, for now.
-    if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
-        # cleanup logs and commit to git
+if [[ "$RUN_TESTS" == "true" || "$RUN_BDD_TESTS" == "true" ]]; then
+    # cleanup logs and push up to S3
 
-        #Delete logs older then 2 weeks
-        bash delete_old_logs.sh
+    # Delete logs older then 2 weeks, if any
+    bash delete_old_logs.sh
       
-        # Push the output logs/screenshots to Github for auditing purposes
-        echo "Pushing test results to ${LOG_DIR}..."
-        git add nightly_logs/
-        git add "${LOG_DIR}/nightly_output_$TODAYS_DATE.txt"
-        git add ${LOG_DIR}/*
-        git commit -m "Add nightly output for $TODAYS_DATE"
-        git pull origin ${GH_BRANCH}
-        git checkout ${GH_BRANCH}
-        git push origin ${GH_BRANCH}
+    if [[ -n $LOG_S3_PATH ]]; then
+        # Push the output logs/screenshots to S3 for review/auditing purposesa
+        echo "Pushing test results to ${LOG_S3_PATH}..."
+        if aws s3 cp ${LOG_DIR} ${LOG_S3_PATH}/${LOG_DIR} --recursive; then
+            echo "Test results successfully pushed to S3."
+            # clean up log dir
+            rm -r $LOG_DIR
+        else
+            echo "Error pushing test results to S3. Log files remain locally in ${LOG_DIR}"
+        fi
+    else
+        echo "Not pushing results to S3 because no log-s3-path was specified on the command line. Log files remian locally in ${LOG_DIR}"
     fi
 fi
 
 # Decide on resource destruction based on the smoke test result or DESTROY flag
 if [[ "$DESTROY" == "true" ]] || [ $SMOKE_TEST_STATUS -ne 0 ]; then
+  # This sleep appears to eliminate a timine issue w/ DynamoDB and the terraform lock file.
   echo "Waiting 15 minutes before reclaiming resources."
   sleep 15m
   echo "Destroying resources..."

--- a/tests/nightly_tests/set_test_params.sh
+++ b/tests/nightly_tests/set_test_params.sh
@@ -29,17 +29,17 @@ export UNITY_USER=$(get_ssm_val "$UNITY_USER_SSM")
 UNITY_PASSWORD_SSM="${SSM_PREFIX}/password"
 export UNITY_PASSWORD=$(get_ssm_val "$UNITY_PASSWORD_SSM")
 
-DOCKSTORE_API_SSM="${SSM_PREFIX}/dockstore/api"
-export DOCKSTORE_API=$(get_ssm_val "$DOCKSTORE_API_SSM")
+# DOCKSTORE_API_SSM="${SSM_PREFIX}/dockstore/api"
+# export DOCKSTORE_API=$(get_ssm_val "$DOCKSTORE_API_SSM")
 
-DOCKSTORE_TOKEN_SSM="${SSM_PREFIX}/dockstore/token"
-export DOCKSTORE_TOKEN=$(get_ssm_val "$DOCKSTORE_TOKEN_SSM")
+# DOCKSTORE_TOKEN_SSM="${SSM_PREFIX}/dockstore/token"
+# export DOCKSTORE_TOKEN=$(get_ssm_val "$DOCKSTORE_TOKEN_SSM")
 
-AIRFLOW_USER_SSM="${SSM_PREFIX}/airflow/user"
-export AIRFLOW_USER=$(get_ssm_val "$AIRFLOW_USER_SSM")
+# AIRFLOW_USER_SSM="${SSM_PREFIX}/airflow/user"
+# export AIRFLOW_USER=$(get_ssm_val "$AIRFLOW_USER_SSM")
 
-AIRFLOW_PASS_SSM="${SSM_PREFIX}/airflow/pass"
-export AIRFLOW_PASS=$(get_ssm_val "$AIRFLOW_PASS_SSM")
+# AIRFLOW_PASS_SSM="${SSM_PREFIX}/airflow/pass"
+# export AIRFLOW_PASS=$(get_ssm_val "$AIRFLOW_PASS_SSM")
 
 # ---------------------------------------
 # Test runtime


### PR DESCRIPTION
## Purpose
It's a security exposure to push log files to git, not to mention can bloat history and commits compounded by the move of nightly tests to monorepo. Instead, log files should be pushed to an S3 bucket, optionally specified on the run.sh command line. For the sake of easy debugging, the last two weeks of log files will be retained locally.

## Testing
- Changes have been run as part of the nightly tests on the Unity-CM bastion host for the past few days.