### PR TITLE
Remove mcp policy

### DIFF
--- a/tests/nightly_tests/cloudformation-template/unity-mc.main.template.yaml
+++ b/tests/nightly_tests/cloudformation-template/unity-mc.main.template.yaml
@@ -256,7 +256,7 @@ Resources:
 
         # TODO: need to generalize for JPL, MCP and normal AWS accounts; currently these are specific to MCP
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DatalakeKinesisPolicy"
+        # Removed McpToolsAccessPolicy and DatalakeKinesisPolicy as they no longer exist
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy_Ondemand"
       PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"

--- a/tests/nightly_tests/cloudformation-template/unity-mc.main.template.yaml
+++ b/tests/nightly_tests/cloudformation-template/unity-mc.main.template.yaml
@@ -257,7 +257,6 @@ Resources:
         # TODO: need to generalize for JPL, MCP and normal AWS accounts; currently these are specific to MCP
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DatalakeKinesisPolicy"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/McpToolsAccessPolicy"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/U-CS_Service_Policy_Ondemand"
       PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${PrivilegedPolicyName}"


### PR DESCRIPTION
# Remove non-existent MCP policies

## Purpose
Remove two policies that no longer exist (McpToolsAccessPolicy and DatalakeKinesisPolicy) to fix deployment errors

## Proposed Changes
- [REMOVE] McpToolsAccessPolicy from IAM role policies
- [REMOVE] DatalakeKinesisPolicy from IAM role policies

## Issues
Fixes deployment error: "Policy McpToolsAccessPolicy and DatalakeKinesisPolicy does not exist or is not attachable"

## Testing
- Tested deployment in hargitay/dev venue
- Stack created successfully without the removed policies