### PR TITLE
Changes unity-ui to unity-portal

### DIFF
--- a/tests/nightly_tests/marketplace_config.yaml
+++ b/tests/nightly_tests/marketplace_config.yaml
@@ -9,5 +9,5 @@ MarketplaceItems:
     version: 24.4-stable
   - name: unity-proxy
     version: 24.4-stable
-  - name: unity-ui
+  - name: unity-portal
     version: 24.4-stable

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -137,7 +137,7 @@ while [[ $# -gt 0 ]]; do
             PROXY_VERSION="$2"
             shift 2
             ;;
-        --unity-ui-version)
+        --unity-portal-version)
             UI_VERSION="$2"
             shift 2
             ;;
@@ -302,7 +302,7 @@ git checkout ${GH_BRANCH}
 #
 # Deploy the Management Console using CloudFormation
 #
-bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}" --config-file "$CONFIG_FILE" --mc-sha "$MC_SHA" ${LATEST:+--latest} ${MONITORING_LAMBDA_VERSION:+--unity-cs-monitoring-lambda-version "$MONITORING_LAMBDA_VERSION"} ${APIGATEWAY_VERSION:+--unity-apigateway-version "$APIGATEWAY_VERSION"} ${PROXY_VERSION:+--unity-proxy-version "$PROXY_VERSION"} ${UI_VERSION:+--unity-ui-version "$UI_VERSION"}
+bash deploy.sh --stack-name "${STACK_NAME}" --project-name "${PROJECT_NAME}" --venue-name "${VENUE_NAME}" --mc-version "${MC_VERSION}" --config-file "$CONFIG_FILE" --mc-sha "$MC_SHA" ${LATEST:+--latest} ${MONITORING_LAMBDA_VERSION:+--unity-cs-monitoring-lambda-version "$MONITORING_LAMBDA_VERSION"} ${APIGATEWAY_VERSION:+--unity-apigateway-version "$APIGATEWAY_VERSION"} ${PROXY_VERSION:+--unity-proxy-version "$PROXY_VERSION"} ${UI_VERSION:+--unity-portal-version "$UI_VERSION"}
 
 echo "Deploying Management Console..." >> nightly_output.txt
 echo "Deploying Management Console..."

--- a/tests/nightly_tests/spsmarketplace_config_test.yaml
+++ b/tests/nightly_tests/spsmarketplace_config_test.yaml
@@ -5,5 +5,5 @@ MarketplaceItems:
     version: 0.4
   - name: unity-proxy
     version: 0.13
-  - name: unity-ui
+  - name: unity-portal
     version: 0.8.0


### PR DESCRIPTION
Fixes an issue with `--mc-sha` option and also switches us to installing `unity-portal` (which was renamed from `unity-ui`).