### PR TITLE
Feature/add component landing page url

### DIFF
--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -405,51 +405,47 @@ fi
 rm $TEMP_CONFIG_FILE
 rm $TEMP_FULL_CONFIG
 
-if [[ "$RUN_TESTS" == "true" ]]; then
-  echo "Checking if Docker is installed..."
-  #
-  # Check if Docker is installed
-  #
-  if ! command -v docker &> /dev/null; then
-    echo "Docker not installed. Installing Docker..."
+echo "Checking if Docker is installed..."
+#
+# Check if Docker is installed
+#
+if ! command -v docker &> /dev/null; then
+  echo "Docker not installed. Installing Docker..."
 
-    # Add Docker's official GPG key
-    sudo apt-get update
-    sudo apt-get install -y ca-certificates curl gnupg
-    sudo install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  # Add Docker's official GPG key
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-    # Add the repository to Apt sources
-    echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update
+  # Add the repository to Apt sources
+  echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update
 
-    # Install Docker
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    sudo systemctl start docker
-    sleep 10
-
-    echo "Docker installed successfully."
-  else
-    echo "Docker already installed [OK]"
-  fi
-
-  sudo docker pull selenium/standalone-chrome
-  echo "Launching selenium docker..."
-  CONTAINER_ID=$(sudo docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome)
+  # Install Docker
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo systemctl start docker
   sleep 10
 
-  cp nightly_output.txt selenium_nightly_output.txt
+  echo "Docker installed successfully."
 else
-  echo "Not checking if docker is installed (--run-tests false)."
-fi # END IF RUN-TESTS
+  echo "Docker already installed [OK]"
+fi
+
+sudo docker pull selenium/standalone-chrome
+echo "Launching selenium docker..."
+CONTAINER_ID=$(sudo docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome)
+sleep 10
+
+cp nightly_output.txt selenium_nightly_output.txt
 
 # Run the Selenium test with the landing page URL and 300-second timeout
 echo "Running Management Console verification test..."
-python3 tests/nightly_tests/test_landing_page.py "${LANDING_PAGE_URL}" 300
+python3 test_landing_page.py "${LANDING_PAGE_URL}" 300
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -436,6 +436,14 @@ else
   echo "Docker already installed [OK]"
 fi
 
+echo "Cleaning up any existing Selenium containers..."
+existing_containers=$(sudo docker ps -a --filter "ancestor=selenium/standalone-chrome" --format "{{.ID}}")
+if [ ! -z "$existing_containers" ]; then
+    echo "Stopping and removing existing Selenium containers..."
+    sudo docker stop $existing_containers
+    sudo docker rm $existing_containers
+fi
+
 sudo docker pull selenium/standalone-chrome
 echo "Launching selenium docker..."
 CONTAINER_ID=$(sudo docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome)

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -325,6 +325,14 @@ RAW_SSM_VALUE=$(aws ssm get-parameter --name ${SSM_MC_URL} --query "Parameter.Va
 export MANAGEMENT_CONSOLE_URL="${RAW_SSM_VALUE}"
 echo "Management Console URL: ${MANAGEMENT_CONSOLE_URL}"
 
+# Get the component landing page URL from SSM
+export SSM_COMPONENT_PARAM="/unity/${PROJECT_NAME}/${VENUE_NAME}/component/management-console"
+
+# Get the raw SSM parameter value and extract landing page URL using jq
+COMPONENT_JSON=$(aws ssm get-parameter --name ${SSM_COMPONENT_PARAM} --query "Parameter.Value" --output text)
+LANDING_PAGE_URL=$(echo $COMPONENT_JSON | jq -r '.landingPageUrl')
+echo "Component Landing Page URL: ${LANDING_PAGE_URL}"
+
 # Extract just the hostname with debug prints
 STEP1=$(echo $MANAGEMENT_CONSOLE_URL | sed 's|^http://||' | sed 's|^HTTP://||')
 

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -453,7 +453,7 @@ cp nightly_output.txt selenium_nightly_output.txt
 
 # Run the Selenium test with the landing page URL and 300-second timeout
 echo "Running Management Console verification test..."
-python3 test_landing_page.py "${LANDING_PAGE_URL}" 600
+python3 test_landing_page.py "${LANDING_PAGE_URL}" 1200
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then

--- a/tests/nightly_tests/run.sh
+++ b/tests/nightly_tests/run.sh
@@ -453,7 +453,7 @@ cp nightly_output.txt selenium_nightly_output.txt
 
 # Run the Selenium test with the landing page URL and 300-second timeout
 echo "Running Management Console verification test..."
-python3 test_landing_page.py "${LANDING_PAGE_URL}" 300
+python3 test_landing_page.py "${LANDING_PAGE_URL}" 600
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then

--- a/tests/nightly_tests/test_landing_page.py
+++ b/tests/nightly_tests/test_landing_page.py
@@ -1,0 +1,118 @@
+import boto3
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import selenium.common.exceptions
+import sys
+
+def get_ssm_parameter(parameter_name):
+    """Get parameter value from SSM, supporting cross-account access"""
+    ssm_client = boto3.client('ssm', region_name='us-west-2')
+    
+    # First get the shared services account ID
+    try:
+        account_response = ssm_client.get_parameter(
+            Name='/unity/shared-services/aws/account'
+        )
+        account_id = account_response['Parameter']['Value']
+        
+        # Construct the full ARN for cross-account parameter access
+        parameter_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter{parameter_name}"
+        
+        # Get the actual parameter using the ARN
+        response = ssm_client.get_parameter(
+            Name=parameter_arn,
+            WithDecryption=True
+        )
+        return response['Parameter']['Value']
+    except Exception as e:
+        print(f"Error accessing SSM parameter: {str(e)}")
+        raise
+
+def setup_driver():
+    """Setup Chrome WebDriver with appropriate options"""
+    chrome_options = Options()
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--headless')  # Run in headless mode
+    chrome_options.add_argument('--disable-dev-shm-usage')
+    
+    # Connect to Selenium standalone container
+    driver = webdriver.Remote(
+        command_executor='http://localhost:4444/wd/hub',
+        options=chrome_options
+    )
+    return driver
+
+def test_landing_page(landing_page_url, max_time_seconds=300, interval=10):
+    start_time = time.time()
+    last_error = None
+    attempt = 1
+
+    while (time.time() - start_time) < max_time_seconds:
+        driver = None
+        try:
+            print(f"\nAttempt {attempt} - Time elapsed: {int(time.time() - start_time)} seconds")
+            
+            # Get credentials from SSM
+            username = get_ssm_parameter('/unity/shared-services/cognito/monitoring-username')
+            password = get_ssm_parameter('/unity/shared-services/cognito/monitoring-password')
+            
+            # Setup WebDriver
+            driver = setup_driver()
+            
+            print(f"Navigating to {landing_page_url}")
+            driver.get(landing_page_url)
+            
+            # Wait for username field and login form
+            username_field = WebDriverWait(driver, 20).until(
+                EC.presence_of_element_located((By.ID, "signInFormUsername"))
+            )
+            password_field = driver.find_element(By.ID, "signInFormPassword")
+            
+            # Input credentials
+            username_field.send_keys(username)
+            password_field.send_keys(password)
+            
+            # Find and click the sign-in button
+            sign_in_button = driver.find_element(By.NAME, "signInSubmitButton")
+            sign_in_button.click()
+            
+            # Wait for redirect and check for welcome message
+            welcome_text = WebDriverWait(driver, 20).until(
+                EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'Welcome to the Unity Management Console')]"))
+            )
+            
+            if welcome_text:
+                print("\nSUCCESS: Found 'Welcome to the Unity Management Console' on the page!")
+                return True
+                
+        except Exception as e:
+            last_error = str(e)
+            print(f"Attempt {attempt} failed. Retrying in {interval} seconds...")
+            time.sleep(interval)
+            attempt += 1
+        finally:
+            if driver:
+                driver.quit()
+
+    # If we get here, we've exceeded the maximum time
+    print(f"\nERROR: Failed to verify Management Console after {max_time_seconds} seconds.")
+    if last_error:
+        print(f"Last error encountered: {last_error}")
+    print(f"\nYou can manually verify the Management Console by visiting:")
+    print(f"{landing_page_url}")
+    return False
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 test_landing_page.py <landing_page_url> [max_time_seconds]")
+        sys.exit(1)
+        
+    landing_page_url = sys.argv[1]
+    max_time = int(sys.argv[2]) if len(sys.argv) > 2 else 300
+    success = test_landing_page(landing_page_url, max_time_seconds=max_time)
+    if not success:
+        exit(1)  # Exit with error code if test failed 

--- a/tests/nightly_tests/test_landing_page.py
+++ b/tests/nightly_tests/test_landing_page.py
@@ -44,6 +44,7 @@ def setup_driver():
         command_executor='http://localhost:4444/wd/hub',
         options=chrome_options
     )
+    driver.set_page_load_timeout(30)  # Set page load timeout to 30 seconds
     return driver
 
 def test_landing_page(landing_page_url, max_time_seconds=300, interval=10):
@@ -64,7 +65,11 @@ def test_landing_page(landing_page_url, max_time_seconds=300, interval=10):
             driver = setup_driver()
             
             print(f"Navigating to {landing_page_url}")
-            driver.get(landing_page_url)
+            try:
+                driver.get(landing_page_url)
+            except selenium.common.exceptions.TimeoutException:
+                print("Page load timed out - site may not be ready yet")
+                raise  # Re-raise to trigger retry
             
             # Wait for username field and login form
             username_field = WebDriverWait(driver, 20).until(


### PR DESCRIPTION
## Purpose
Fix nightly test smoke tests to properly handle the top-level proxy URL by adding necessary security group rules and improving error handling in the test scripts.

## Proposed Changes
- [ADD] Security group rule for outbound port 4443 to allow EC2 instance to reach proxy URL
- [ADD] Better error logging in test_landing_page.py to help debug connection issues
- [FIX] Docker container cleanup before starting new Selenium tests to prevent endpoint connection errors
- [CHANGE] Increased page load timeout to handle proxy redirects

## Issues
- Fixes issue where nightly tests fail when trying to access www.dev.mdps.mcp.nasa.gov:4443
- Addresses flaky test behavior due to Docker container conflicts

## Testing
- Tested manually on EC2 instance in AWS environment
- Verified outbound connectivity to proxy URL using curl
- Successfully ran landing page test with new security group rules