### PR TITLE
Update default portal version specified in marketplace_config.yaml

### DIFF
--- a/tests/nightly_tests/marketplace_config.yaml
+++ b/tests/nightly_tests/marketplace_config.yaml
@@ -10,4 +10,4 @@ MarketplaceItems:
   - name: unity-proxy
     version: 24.4-stable
   - name: unity-portal
-    version: 24.4-stable
+    version: 25.1-stable


### PR DESCRIPTION
## Purpose

This PR addresses updating the default version of the portal application that gets ~updated~ installed when a management console instance is deployed.

## Proposed Changes
- [CHANGE] Updated default version of `unity-portal` that is installed by MC from `24.4-stable` to `25.1-stable`.

## Issues
Resolves #87 

## Testing
- Version `25.1-stable` of the portal has been successfully installed in `unity-venue-dev`, `unity-venue-test`, and `unity-venue-ops`