### PR TITLE
Add to STAC file assets: file:size and file:checksum values

### DIFF
--- a/libs/unity-py/CHANGELOG.md
+++ b/libs/unity-py/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2025-05-19
+
+### Added
+* When creating STAC catalogs using the Collection resource, if an asset is a file local to the catalog file, then the file:size and file:checksum values will be added to the asset's STAC entry.
+
 ## [0.10.0] - 2025-02-19
 
 ### Added

--- a/libs/unity-py/pyproject.toml
+++ b/libs/unity-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.10.0"
+version = "0.11.0"
 
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]


### PR DESCRIPTION
## Purpose

* Add file:size and file:checksum attributes to STAC asset values in stage-out catalogs

## Testing

* Ran through TROPESS py-process example notebook
