### PR TITLE
Implement session cognito token expiry

### DIFF
--- a/libs/unity-py/CHANGELOG.md
+++ b/libs/unity-py/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2025-06-09
+
+### Added
+* Cognito token fetching now appropriately stores and checks token expiration on token use.
+
 ## [0.11.0] - 2025-05-19
 
 ### Added

--- a/libs/unity-py/pyproject.toml
+++ b/libs/unity-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unity-sds-client"
-version = "0.11.0"
+version = "0.11.1"
 
 description = "Unity-Py is a Python client to simplify interactions with NASA's Unity Platform."
 authors = ["Anil Natha, Mike Gangl"]


### PR DESCRIPTION
## Purpose
- Implements the cognito token expiration checking

## Proposed Changes
- CHANGE cognito token fetching to store expiry date
- CHANGE _is_expired method to actually validate something

## Issues
- none

## Testing
- Tested with:
```
process_service = unity.client(UnityServices.PROCESS_SERVICE)
process_service.endpoint = "https://api.dev.mdps.mcp.nasa.gov/unity/dev/ogc/api"

processes = process_service.get_processes()
print(process_service._session.get_auth()._token)
print(process_service._session.get_auth()._token_expiration)

for process in processes:
    print("Process ID: {}\n".format(process.id))

time.sleep(3601)

print("retrying with same client")

processes = process_service.get_processes()
print(process_service._session.get_auth()._token)
print(process_service._session.get_auth()._token_expiration)

for process in processes:
    print("Process ID: {}\n".format(process.id))
```
Successfully showed key re-fetching.