### PR TITLE
Updated marketplace_config.yaml to reference version `25.2-stable` of unity-portal

### DIFF
--- a/tests/nightly_tests/marketplace_config.yaml
+++ b/tests/nightly_tests/marketplace_config.yaml
@@ -10,4 +10,4 @@ MarketplaceItems:
   - name: unity-proxy
     version: 24.4-stable
   - name: unity-portal
-    version: 25.1-stable
+    version: 25.2-stable


### PR DESCRIPTION
## Purpose

Updated marketplace_config.yaml to reference version `25.2-stable` of unity-portal

## Proposed Changes

- [CHANGE] Updated version of unity-portal to version `25.2-stable` so that MC deploys this version by default.