### PR TITLE
Update deployment script to point to current MCP AMI

### DIFF
--- a/tests/nightly_tests/set_common_ssm_params.sh
+++ b/tests/nightly_tests/set_common_ssm_params.sh
@@ -119,7 +119,7 @@ CERTIFICATE_ARN_VAL=$(get_ssm_val "${CERTIFICATE_ARN_SSM}")
 # SSM:  /unity/account/eks/amis/aml2-eks-1-29
 #
 EKS_AMI_29_SSM="/unity/account/eks/amis/aml2-eks-1-29"
-EKS_AMI_29_VAL=$(get_ssm_val "/mcp/amis/aml2-eks-1-29")
+EKS_AMI_29_VAL=$(get_ssm_val "/mcp/amis/aml2023-eks-1-29")
 refresh_ssm_param "${EKS_AMI_29_SSM}" "${EKS_AMI_29_VAL}" "processing" "na" "vpc" "unity-all-cs-processing-aml2Eks129Ssm"
 
 #


### PR DESCRIPTION
Fixing nightly deployment which referenced only SSM parameter.

Looks like MCP removed the `/mcp/amis/aml2-eks-1-29` AMI and replaced it with `/mcp/amis/aml2023-eks-1-29`.   The nightly deploy script removes the SSM parameter before creating it again and since the reference SSM didn't exist the unity SSM "/unity/account/eks/amis/aml2-eks-1-29" was removed.

@jpl-btlunsfo, @LucaCinquini is it OK to keep the old "Unity" SSM name or do we need to update it to aml2023 in all the scripts?